### PR TITLE
Adding component modal ref so components can redraw within a modal.

### DIFF
--- a/src/templates/bootstrap4/componentModal/form.ejs
+++ b/src/templates/bootstrap4/componentModal/form.ejs
@@ -9,9 +9,9 @@
       {% } else { %}
       <button class="formio-dialog-close float-right btn btn-secondary btn-sm" aria-label="Close button. Click to get back to the form" ref="modalClose"></button>
       {% } %}
-      <div ref="modalContents">
+      <div ref="modalContent">
         {% if (ctx.visible) { %}
-        {{ctx.children}}
+        <div ref="componentContent">{{ctx.children}}</div>
         {% } %}
         <div class="formio-dialog-buttons">
           {% if (ctx.options.vpat) { %}

--- a/src/templates/bootstrap5/componentModal/form.ejs
+++ b/src/templates/bootstrap5/componentModal/form.ejs
@@ -9,9 +9,9 @@
       {% } else { %}
       <button class="formio-dialog-close float-end btn btn-secondary btn-sm" aria-label="Close button. Click to get back to the form" ref="modalClose"></button>
       {% } %}
-      <div ref="modalContents">
+      <div ref="modalContent">
         {% if (ctx.visible) { %}
-        {{ctx.children}}
+        <div ref="componentContent">{{ctx.children}}</div>
         {% } %}
         <div class="formio-dialog-buttons">
           {% if (ctx.options.vpat) { %}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8746

## Description

Previously we had to implement several hacks within our renderer to allow for Nested Wizards to show and function within a Modal. The reason it was problematic is because it could not redraw within the modal since there is no reference that can be used to bind the element of the nested wizard against.  This solves that problem.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
