### PR TITLE
FIO-10007: fixed display of file validation errors

### DIFF
--- a/src/templates/bootstrap4/file/form.ejs
+++ b/src/templates/bootstrap4/file/form.ejs
@@ -125,16 +125,35 @@
       </div>
     {% }) %}
     {% ctx.filesToUpload.forEach(function(file) { %}
-      {% if (file.status === 'progress') { %}
-        <div class="text-right">{{ctx.fileSize(file.size)}}</div>
-        <div class="status progress">
-          <div id={{file.id}} class="progress-bar" role="progressbar" aria-valuenow="{{file.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{file.progress}}%" ref="progress">
-            <span class="sr-only">{{file.progress}}% {{ctx.t('completeStatus')}}</span>
+        <li class="list-group-item">
+          <div class="row align-center">
+            <div class="col-md-{{ctx.columns.name}}">
+              <div>{{file.originalName || file.name}}</div>
+              {% if (file.status === 'progress') { %}
+                <div class="status progress">
+                  <div id={{file.id}} class="progress-bar" role="progressbar" aria-valuenow="{{file.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{file.progress}}%" ref="progress">
+                    <span class="sr-only">{{file.progress}}% {{ctx.t('completeStatus')}}</span>
+                  </div>
+                </div>
+              {% } else { %}
+                <div class="status text-{{file.status === 'error' ? 'danger': file.status}}">{{ctx.t(file.message)}}</div>
+              {% } %}
+            </div>
+            <div class="col-md-{{ctx.columns.size}}">{{ctx.fileSize(file.size)}}</div>
+            {% if (ctx.self.hasTypes) { %}
+              <div class="col-md-{{ctx.columns.type}}">
+                <select class="file-type" ref="fileType">
+                  {% ctx.component.fileTypes.map(function(type) { %}
+                    <option class="test" value="{{ type.value }}" {% if (type.label === file.fileType) { %}selected="selected"{% } %}>{{ctx.t(type.label)}}</option>
+                  {% }); %}
+                </select>
+              </div>
+            {% } %}
+            {% if (!ctx.isSyncing && file.status !== 'success') { %}
+              <div class="col-md-{{ctx.columns.actions}} justify-center"><i tabindex="0" class="{{ctx.iconClass('remove')}}" ref="fileToSyncRemove"></i></div>
+            {% } %}
           </div>
-        </div>
-      {% } else { %}
-        <div class="status text-{{file.status === 'error' ? 'danger': file.status}}">{{ctx.t(file.message)}}</div>
-      {% } %}
+        </li>
     {% }) %}
   </div>
 {% } %}

--- a/src/templates/bootstrap5/file/form.ejs
+++ b/src/templates/bootstrap5/file/form.ejs
@@ -125,16 +125,37 @@
       </div>
     {% }) %}
     {% ctx.filesToUpload.forEach(function(file) { %}
-      {% if (file.status === 'progress') { %}
-        <div class="text-end">{{ctx.fileSize(file.size)}}</div>
-        <div class="status progress">
-          <div id="{{file.id}}" class="progress-bar" role="progressbar" aria-valuenow="{{file.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{file.progress}}%" ref="progress">
-            <span class="visually-hidden">{{file.progress}}% {{ctx.t('completeStatus')}}</span>
+      <li class="list-group-item">
+        <div class="row align-center">
+          <div class="col-md-{{ctx.columns.name}}">
+            <div>{{file.originalName || file.name}}</div>
+            {% if (file.status === 'progress') { %}
+              <div class="status progress">
+                <div id="{{file.id}}" class="progress-bar" role="progressbar" aria-valuenow="{{file.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{file.progress}}%" ref="progress">
+                  <span class="visually-hidden">{{file.progress}}% {{ctx.t('completeStatus')}}</span>
+                </div>
+              </div>
+            {% } else { %}
+              <div class="status text-{{file.status === 'error' ? 'danger': file.status}}">{{ctx.t(file.message)}}</div>
+            {% } %}
           </div>
+          <div class="col-md-{{ctx.columns.size}}">{{ctx.fileSize(file.size)}}</div>
+          {% if (ctx.self.hasTypes) { %}
+            <div class="col-md-{{ctx.columns.type}}">
+              <select class="file-type" ref="fileType">
+                {% ctx.component.fileTypes.map(function(type) { %}
+                  <option class="test" value="{{ type.value }}" {% if (type.label === file.fileType) { %}selected="selected"{% } %}>{{ctx.t(type.label)}}</option>
+                {% }); %}
+              </select>
+            </div>
+          {% } %}
+          {% if (file.status === 'progress') { %}
+            <div class="col-md-{{ctx.columns.actions}} justify-center"><i id="abort-{{file.id}}" tabindex="0" class="{{ctx.iconClass('ban')}}"></i></div>
+          {% } else if (!ctx.isSyncing && file.status !== 'success') { %}
+            <div class="col-md-{{ctx.columns.actions}} justify-center"><i tabindex="0" class="{{ctx.iconClass('remove')}}" ref="fileToSyncRemove"></i></div>
+          {% } %}
         </div>
-      {% } else { %}
-        <div class="status text-{{file.status === 'error' ? 'danger': file.status}}">{{ctx.t(file.message)}}</div>
-      {% } %}
+      </li>
     {% }) %}
   </div>
 {% } %}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10007

## Description

Fixed templates for proper display of validation errors when file component display as image set to true.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Linked and tested manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
