### PR TITLE
fix: use correct Bootstrap 5 class for select element

### DIFF
--- a/src/templates/bootstrap5/multipleMasksInput/form.ejs
+++ b/src/templates/bootstrap5/multipleMasksInput/form.ejs
@@ -3,7 +3,7 @@
   ref="{{ctx.input.ref ? ctx.input.ref : 'input'}}"
 >
   <select
-    class="form-control formio-multiple-mask-select"
+    class="form-select formio-multiple-mask-select"
     id="{{ctx.key}}-mask"
     ref="select"
     {% if (ctx.input.attr.disabled) { %}disabled{% } %}>


### PR DESCRIPTION
## Summary

This PR fixes an incorrect Bootstrap 5 class used on a `<select>` element.

The `form-control` class was applied to a `<select>`, but in Bootstrap 5 the correct class for select elements is `form-select`. Using `form-select` ensures proper styling and behavior according to Bootstrap conventions.
https://getbootstrap.com/docs/5.0/forms/select/

### Changes

* Replaced `form-control` with `form-select` for the affected `<select>` element.
